### PR TITLE
Add text cleaning and anonymization to dataset loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
 # Legal-LLM
+
+## Colab Environment Setup
+
+Run the following script in Google Colab or a local notebook to install dependencies,
+print hardware information, and initialize random seeds.
+
+```python
+!python setup_colab.py
+```
+
+The script installs required libraries, downloads the `en_core_web_sm` spaCy model if
+necessary, displays CUDA/CPU details, defines a `set_seed` helper, and sets the default
+seed to `42` for reproducibility.
+
+## Loading training data
+
+Use `data_utils.load_dataframes` to ensure your datasets meet the expected schema. It
+accepts preloaded DataFrames or reads CSV/Parquet files from a config and prints shapes,
+null counts, and example rows while validating that `text` and `summary` are non-empty
+strings. The loader also applies a `clean_text` routine to produce `text_clean` and
+`summary_clean` columns that normalize Unicode, standardize punctuation, drop page/line
+numbers, and optionally anonymize names.
+
+```python
+from data_utils import load_dataframes
+
+# Option 1: pass existing DataFrames
+df_train, df_val, df_test = load_dataframes(df_train, df_val, df_test)
+
+# Option 2: read from paths defined in CONFIG
+df_train, df_val, df_test = load_dataframes()
+print(df_train[["text", "text_clean"]].head())
+```

--- a/data_utils.py
+++ b/data_utils.py
@@ -1,0 +1,175 @@
+import re
+import unicodedata
+from typing import Dict, Optional, Tuple
+
+import pandas as pd
+
+CONFIG = {
+    "train_path": "train.csv",
+    "val_path": "val.csv",
+    "test_path": "test.csv",
+}
+
+
+def clean_text(x: str, anonymize: bool = True) -> Tuple[str, Dict[str, str]]:
+    """Return normalized text and a mapping of anonymized names.
+
+    Parameters
+    ----------
+    x : str
+        Input string to clean.
+    anonymize : bool, optional
+        Whether to replace detected names with placeholders, by default True.
+
+    Returns
+    -------
+    Tuple[str, Dict[str, str]]
+        The cleaned text and a mapping from placeholder to original name.
+    """
+
+    if not isinstance(x, str):
+        return x, {}
+
+    text = unicodedata.normalize("NFKC", x)
+
+    # Standardize quotes, dashes and bullet symbols
+    replacements = {
+        "“": '"',
+        "”": '"',
+        "‘": "'",
+        "’": "'",
+        "—": "-",
+        "–": "-",
+        "−": "-",
+        "•": "-",
+        "·": "-",
+    }
+    for src, tgt in replacements.items():
+        text = text.replace(src, tgt)
+
+    # Remove page numbers, line numbers, and simple header/footer patterns
+    text = re.sub(r"\bPage\s+\d+(?:\s+of\s+\d+)?\b", "", text, flags=re.IGNORECASE)
+    text = re.sub(r"^\s*\d+\s*$", "", text, flags=re.MULTILINE)
+    text = re.sub(r"(?m)^(?:Header|Footer):.*$", "", text)
+
+    # Normalize whitespace and collapse multiple newlines
+    text = re.sub(r"\r\n?", "\n", text)
+    text = re.sub(r"\n{2,}", "\n\n", text)
+    text = re.sub(r"[ \t]+", " ", text)
+    text = text.strip()
+
+    name_map: Dict[str, str] = {}
+    if anonymize:
+        judge_idx = 1
+        def_idx = 1
+
+        def replace_judge(match: re.Match) -> str:
+            nonlocal judge_idx
+            name = match.group(1)
+            placeholder = f"JUDGE_{judge_idx}"
+            judge_idx += 1
+            name_map[placeholder] = name
+            return placeholder
+
+        def replace_defendant(match: re.Match) -> str:
+            nonlocal def_idx
+            name = match.group(0)
+            placeholder = f"DEFENDANT_{def_idx}"
+            def_idx += 1
+            name_map[placeholder] = name
+            return placeholder
+
+        # Replace judges/justices first to avoid double replacement
+        text = re.sub(
+            r"(?:Judge|Justice) ([A-Z][a-z]+ [A-Z][a-z]+)",
+            replace_judge,
+            text,
+        )
+        # Replace remaining capitalized first+last names
+        text = re.sub(r"\b[A-Z][a-z]+ [A-Z][a-z]+\b", replace_defendant, text)
+
+    return text, name_map
+
+def _read_dataframe(path: str) -> pd.DataFrame:
+    if path.endswith(".csv"):
+        return pd.read_csv(path)
+    if path.endswith(".parquet"):
+        return pd.read_parquet(path)
+    raise ValueError(f"Unsupported file extension for {path}")
+
+
+def _validate_dataframe(df: pd.DataFrame, name: str) -> None:
+    required_cols = ["doc_id", "text", "summary"]
+    if list(df.columns) != required_cols:
+        raise AssertionError(
+            f"{name} must have columns {required_cols}, got {list(df.columns)}"
+        )
+
+    # Ensure 'text' and 'summary' are non-empty strings after strip
+    for col in ["text", "summary"]:
+        if not df[col].map(lambda x: isinstance(x, str) and x.strip() != "").all():
+            raise AssertionError(f"Column '{col}' in {name} contains empty strings or non-str values")
+
+    print(f"{name} shape: {df.shape}")
+    print(f"{name} null counts:\n{df.isna().sum()}")
+    print(f"{name} examples:\n{df.head(2)}\n")
+
+
+def _clean_dataframe(df: pd.DataFrame) -> pd.DataFrame:
+    """Add cleaned text and summary columns to a copy of ``df``."""
+
+    df = df.copy()
+    df["text_clean"], df["text_map"] = zip(*df["text"].map(clean_text))
+    df["summary_clean"], df["summary_map"] = zip(*df["summary"].map(clean_text))
+    return df
+
+
+def load_dataframes(
+    df_train: Optional[pd.DataFrame] = None,
+    df_val: Optional[pd.DataFrame] = None,
+    df_test: Optional[pd.DataFrame] = None,
+    config: Optional[Dict[str, str]] = None,
+) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    cfg = CONFIG if config is None else config
+    if df_train is None:
+        df_train = _read_dataframe(cfg["train_path"])
+    if df_val is None:
+        df_val = _read_dataframe(cfg["val_path"])
+    if df_test is None:
+        df_test = _read_dataframe(cfg["test_path"])
+
+    _validate_dataframe(df_train, "df_train")
+    _validate_dataframe(df_val, "df_val")
+    _validate_dataframe(df_test, "df_test")
+
+    df_train = _clean_dataframe(df_train)
+    df_val = _clean_dataframe(df_val)
+    df_test = _clean_dataframe(df_test)
+
+    for name, df in [("df_train", df_train), ("df_val", df_val), ("df_test", df_test)]:
+        print(
+            f"{name} cleaned samples:\n"
+            f"{df[['text', 'text_clean', 'summary', 'summary_clean']].head(3)}\n"
+        )
+
+    return df_train, df_val, df_test
+
+
+if __name__ == "__main__":
+    sample = {
+        "doc_id": [1, 2, 3],
+        "text": [
+            "FACTS: Judge Alice Smith heard the case. Page 1\nJohn Doe appeared.",
+            "ISSUE: Whether — given the evidence — the defendant Jane Roe was liable.",
+            "HELD: Justice Bob Jones concluded the matter on page 2.",
+        ],
+        "summary": [
+            "Judge Alice Smith summarized the facts.",
+            "The issue involved Jane Roe's liability.",
+            "Justice Bob Jones delivered the holding.",
+        ],
+    }
+    df_t = pd.DataFrame(sample)
+    df_v = pd.DataFrame(sample)
+    df_te = pd.DataFrame(sample)
+    load_dataframes(df_t, df_v, df_te)

--- a/setup_colab.py
+++ b/setup_colab.py
@@ -1,0 +1,73 @@
+import os
+import sys
+import subprocess
+import random
+import platform
+
+PACKAGES = [
+    "transformers>=4.42",
+    "datasets",
+    "accelerate",
+    "peft",
+    "bitsandbytes",
+    "sentencepiece",
+    "evaluate",
+    "rouge_score",
+    "bert_score",
+    "wandb",
+    "pandas",
+    "scikit-learn",
+    "faiss-cpu",
+    "nltk",
+    "tiktoken",
+    "unidecode",
+    "spacy",
+]
+
+def install_packages():
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "-q"] + PACKAGES)
+
+
+def ensure_spacy_model(model: str = "en_core_web_sm"):
+    try:
+        import spacy
+        spacy.load(model)
+    except (ImportError, OSError):
+        subprocess.check_call([sys.executable, "-m", "spacy", "download", model])
+        import spacy  # noqa: F401
+        spacy.load(model)
+
+
+def set_seed(seed: int = 42):
+    import numpy as np
+    import torch
+
+    os.environ["PYTHONHASHSEED"] = str(seed)
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
+
+
+def print_system_info():
+    import torch
+
+    print(f"Python version: {sys.version}")
+    print(f"PyTorch version: {torch.__version__}")
+    if torch.cuda.is_available():
+        print("CUDA is available")
+        print(f"CUDA version: {torch.version.cuda}")
+        print(f"GPU: {torch.cuda.get_device_name(0)}")
+    else:
+        print("CUDA not available. Using CPU")
+    print(f"CPU: {platform.processor()}")
+
+
+if __name__ == "__main__":
+    install_packages()
+    ensure_spacy_model()
+    print_system_info()
+    set_seed(42)
+    print("Random seeds set to 42")


### PR DESCRIPTION
## Summary
- implement `clean_text` to normalize Unicode, standardize punctuation, remove page/line numbers, and anonymize names with reversible placeholders
- integrate cleaning into `load_dataframes` to add `text_clean`/`summary_clean` columns and show before/after samples
- document dataset cleaning in the README

## Testing
- `pip install pandas` *(fails: Could not find a version that satisfies the requirement pandas)*
- `python data_utils.py` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `python setup_colab.py` *(fails: Could not find a version that satisfies the requirement transformers>=4.42)*

------
https://chatgpt.com/codex/tasks/task_e_68aac1187ab083269989905f2b7b546b