### PR TITLE
Add text cleaning, dataset statistics, deduplication, and task transforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,96 @@
 # Legal-LLM
+
+## Colab Environment Setup
+
+Run the following script in Google Colab or a local notebook to install dependencies,
+print hardware information, and initialize random seeds.
+
+```python
+!python setup_colab.py
+```
+
+The script installs required libraries, downloads the `en_core_web_sm` spaCy model if
+necessary, displays CUDA/CPU details, defines a `set_seed` helper, and sets the default
+seed to `42` for reproducibility.
+
+## Loading training data
+
+Use `data_utils.load_dataframes` to ensure your datasets meet the expected schema. It
+accepts preloaded DataFrames or reads CSV/Parquet files from a config and prints shapes,
+null counts, and example rows while validating that `text` and `summary` are non-empty
+strings. The loader also applies a `clean_text` routine to produce `text_clean` and
+`summary_clean` columns that normalize Unicode, standardize punctuation, drop page/line
+numbers, and optionally anonymize names. Near-duplicate `text_clean` entries in `df_train`
+are removed using a SimHash similarity threshold of `0.9` to prevent leakage against
+`df_val` and `df_test`. A mapping of dropped indices to `doc_id` is returned.
+
+The loader verifies that `doc_id` values are unique across splits and writes the
+cleaned DataFrames to canonical Parquet files (`train.parquet`, `val.parquet`,
+`test.parquet`).
+
+```python
+from data_utils import load_dataframes
+
+# Option 1: pass existing DataFrames
+df_train, df_val, df_test, dropped = load_dataframes(df_train, df_val, df_test)
+
+# Option 2: read from paths defined in CONFIG
+df_train, df_val, df_test, dropped = load_dataframes()
+print("Dropped duplicates:", dropped)
+print(df_train[["text", "text_clean"]].head())
+```
+
+## Dataset statistics
+
+After loading and cleaning the splits, call `analyze_datasets` to inspect length
+distributions and vocabulary overlap. The helper saves histogram plots for character
+and token lengths using tiktoken's `cl100k_base` encoder and reports percentiles
+(`p50`, `p90`, `p95`, `p99`). It also lemmatizes each split with spaCy to compute the
+Jaccard overlap of vocabularies between train/val/test.
+
+```python
+from data_utils import analyze_datasets
+
+df_train, df_val, df_test, dropped = load_dataframes()
+analyze_datasets(df_train, df_val, df_test)
+```
+
+## Task-specific dataset transforms
+
+Three helpers in `data_utils` generate `prompt`/`target` pairs for downstream
+modeling tasks:
+
+- **Abstractive summarization** – `build_summarization_dataset` uses
+  `text_clean` as the input and `summary_clean` as the target.
+- **Legal QA** – `build_legal_qa_dataset` extracts `ISSUE` and `HOLDING/HELD`
+  sections from `text_clean` to form synthetic question/answer pairs.
+- **Headnote generation** – `build_headnote_dataset` creates structured targets
+  with `Facts`, `Issue`, `Holding`, and `Reasoning` sections.
+
+Each function returns a DataFrame with `doc_id`, `prompt`, and `target` columns:
+
+```python
+from data_utils import (
+    build_summarization_dataset,
+    build_legal_qa_dataset,
+    build_headnote_dataset,
+)
+
+df_train, _, _, _ = load_dataframes()
+summ_df = build_summarization_dataset(df_train)
+qa_df = build_legal_qa_dataset(df_train)
+headnote_df = build_headnote_dataset(df_train)
+```
+
+## Prompt templates
+
+`prompts.py` exposes reusable templates with explicit `SYSTEM` and `USER` roles for a legal tone.
+Use `build_prompt(text, style)` to format case text into a prompt. Available styles are `summarization`, `headnote`, and `qa`:
+
+```python
+from prompts import build_prompt
+
+print(build_prompt("Some case text", style="headnote"))
+```
+
+The dataset helpers above automatically apply the appropriate templates when generating `prompt`/`target` pairs.

--- a/data_utils.py
+++ b/data_utils.py
@@ -1,0 +1,436 @@
+import os
+import re
+import unicodedata
+import hashlib
+from typing import Dict, Optional, Tuple
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import spacy
+import tiktoken
+from prompts import build_prompt
+
+CONFIG = {
+    "train_path": "train.csv",
+    "val_path": "val.csv",
+    "test_path": "test.csv",
+    "train_parquet": "train.parquet",
+    "val_parquet": "val.parquet",
+    "test_parquet": "test.parquet",
+}
+
+
+def clean_text(x: str, anonymize: bool = True) -> Tuple[str, Dict[str, str]]:
+    """Return normalized text and a mapping of anonymized names.
+
+    Parameters
+    ----------
+    x : str
+        Input string to clean.
+    anonymize : bool, optional
+        Whether to replace detected names with placeholders, by default True.
+
+    Returns
+    -------
+    Tuple[str, Dict[str, str]]
+        The cleaned text and a mapping from placeholder to original name.
+    """
+
+    if not isinstance(x, str):
+        return x, {}
+
+    text = unicodedata.normalize("NFKC", x)
+
+    # Standardize quotes, dashes and bullet symbols
+    replacements = {
+        "“": '"',
+        "”": '"',
+        "‘": "'",
+        "’": "'",
+        "—": "-",
+        "–": "-",
+        "−": "-",
+        "•": "-",
+        "·": "-",
+    }
+    for src, tgt in replacements.items():
+        text = text.replace(src, tgt)
+
+    # Remove page numbers, line numbers, and simple header/footer patterns
+    text = re.sub(r"\bPage\s+\d+(?:\s+of\s+\d+)?\b", "", text, flags=re.IGNORECASE)
+    text = re.sub(r"^\s*\d+\s*$", "", text, flags=re.MULTILINE)
+    text = re.sub(r"(?m)^(?:Header|Footer):.*$", "", text)
+
+    # Normalize whitespace and collapse multiple newlines
+    text = re.sub(r"\r\n?", "\n", text)
+    text = re.sub(r"\n{2,}", "\n\n", text)
+    text = re.sub(r"[ \t]+", " ", text)
+    text = text.strip()
+
+    name_map: Dict[str, str] = {}
+    if anonymize:
+        judge_idx = 1
+        def_idx = 1
+
+        def replace_judge(match: re.Match) -> str:
+            nonlocal judge_idx
+            name = match.group(1)
+            placeholder = f"JUDGE_{judge_idx}"
+            judge_idx += 1
+            name_map[placeholder] = name
+            return placeholder
+
+        def replace_defendant(match: re.Match) -> str:
+            nonlocal def_idx
+            name = match.group(0)
+            placeholder = f"DEFENDANT_{def_idx}"
+            def_idx += 1
+            name_map[placeholder] = name
+            return placeholder
+
+        # Replace judges/justices first to avoid double replacement
+        text = re.sub(
+            r"(?:Judge|Justice) ([A-Z][a-z]+ [A-Z][a-z]+)",
+            replace_judge,
+            text,
+        )
+        # Replace remaining capitalized first+last names
+        text = re.sub(r"\b[A-Z][a-z]+ [A-Z][a-z]+\b", replace_defendant, text)
+
+    return text, name_map
+
+def _read_dataframe(path: str) -> pd.DataFrame:
+    if path.endswith(".csv"):
+        return pd.read_csv(path)
+    if path.endswith(".parquet"):
+        return pd.read_parquet(path)
+    raise ValueError(f"Unsupported file extension for {path}")
+
+
+def _validate_dataframe(df: pd.DataFrame, name: str) -> None:
+    required_cols = ["doc_id", "text", "summary"]
+    if list(df.columns) != required_cols:
+        raise AssertionError(
+            f"{name} must have columns {required_cols}, got {list(df.columns)}"
+        )
+
+    # Ensure 'text' and 'summary' are non-empty strings after strip
+    for col in ["text", "summary"]:
+        if not df[col].map(lambda x: isinstance(x, str) and x.strip() != "").all():
+            raise AssertionError(f"Column '{col}' in {name} contains empty strings or non-str values")
+
+    print(f"{name} shape: {df.shape}")
+    print(f"{name} null counts:\n{df.isna().sum()}")
+    print(f"{name} examples:\n{df.head(2)}\n")
+
+
+def _assert_disjoint_doc_ids(
+    df_train: pd.DataFrame, df_val: pd.DataFrame, df_test: pd.DataFrame
+) -> None:
+    """Raise if any ``doc_id`` appears in more than one split."""
+
+    train_ids, val_ids, test_ids = (
+        set(df_train["doc_id"]),
+        set(df_val["doc_id"]),
+        set(df_test["doc_id"]),
+    )
+    overlap = (train_ids & val_ids) | (train_ids & test_ids) | (val_ids & test_ids)
+    if overlap:
+        raise AssertionError(
+            f"doc_id overlap across splits: {sorted(list(overlap))[:10]}"
+        )
+    print("No doc_id overlap detected across splits")
+
+
+def _save_splits_to_parquet(
+    df_train: pd.DataFrame,
+    df_val: pd.DataFrame,
+    df_test: pd.DataFrame,
+    cfg: Dict[str, str],
+) -> None:
+    """Persist ``df_train``, ``df_val`` and ``df_test`` to Parquet files."""
+
+    for split, df in [("train", df_train), ("val", df_val), ("test", df_test)]:
+        path = cfg.get(f"{split}_parquet", f"{split}.parquet")
+        df.to_parquet(path, index=False)
+        print(f"Saved {split} split to {path}")
+
+
+def _clean_dataframe(df: pd.DataFrame) -> pd.DataFrame:
+    """Add cleaned text and summary columns to a copy of ``df``."""
+
+    df = df.copy()
+    df["text_clean"], df["text_map"] = zip(*df["text"].map(clean_text))
+    df["summary_clean"], df["summary_map"] = zip(*df["summary"].map(clean_text))
+    return df
+
+
+def _simhash(text: str) -> int:
+    """Return a 64-bit SimHash fingerprint of ``text``."""
+    tokens = text.split()
+    if not tokens:
+        return 0
+    shingles = (
+        [" ".join(tokens[i : i + 3]) for i in range(len(tokens) - 2)]
+        if len(tokens) >= 3
+        else tokens
+    )
+    v = [0] * 64
+    for sh in shingles:
+        h = int(hashlib.md5(sh.encode("utf-8")).hexdigest(), 16)
+        for i in range(64):
+            bit = 1 << i
+            v[i] += 1 if h & bit else -1
+    fingerprint = 0
+    for i, val in enumerate(v):
+        if val >= 0:
+            fingerprint |= 1 << i
+    return fingerprint
+
+
+def _simhash_similarity(a: int, b: int) -> float:
+    """Similarity between two SimHash fingerprints."""
+    return 1 - (bin(a ^ b).count("1") / 64)
+
+
+def drop_near_duplicates(
+    df_train: pd.DataFrame,
+    df_val: pd.DataFrame,
+    df_test: pd.DataFrame,
+    threshold: float = 0.9,
+) -> Tuple[pd.DataFrame, Dict[int, int]]:
+    """Remove near-duplicate rows from ``df_train`` using SimHash.
+
+    Rows in ``df_train`` that are similar to each other or to rows in ``df_val``/
+    ``df_test`` are dropped to prevent data leakage. Returns the deduplicated
+    DataFrame and a mapping from original index to ``doc_id`` for dropped rows.
+    """
+
+    val_hashes = df_val["text_clean"].map(_simhash).to_numpy()
+    test_hashes = df_test["text_clean"].map(_simhash).to_numpy()
+
+    drop_idx: list[int] = []
+    drop_map: Dict[int, int] = {}
+    kept_hashes: list[int] = []
+
+    for idx, row in df_train.iterrows():
+        h = _simhash(row["text_clean"])
+        similar_to_val = any(_simhash_similarity(h, vh) >= threshold for vh in val_hashes)
+        similar_to_test = any(
+            _simhash_similarity(h, th) >= threshold for th in test_hashes
+        )
+        similar_to_train = any(
+            _simhash_similarity(h, kh) >= threshold for kh in kept_hashes
+        )
+        if similar_to_val or similar_to_test or similar_to_train:
+            drop_idx.append(idx)
+            drop_map[idx] = row["doc_id"]
+        else:
+            kept_hashes.append(h)
+
+    if drop_idx:
+        print(f"Removed {len(drop_idx)} near-duplicate rows from train")
+    else:
+        print("No near-duplicates detected in train")
+
+    df_dedup = df_train.drop(index=drop_idx).reset_index(drop=True)
+    return df_dedup, drop_map
+
+def load_dataframes(
+    df_train: Optional[pd.DataFrame] = None,
+    df_val: Optional[pd.DataFrame] = None,
+    df_test: Optional[pd.DataFrame] = None,
+    config: Optional[Dict[str, str]] = None,
+    dup_threshold: float = 0.9,
+) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame, Dict[int, int]]:
+    cfg = CONFIG if config is None else config
+    if df_train is None:
+        df_train = _read_dataframe(cfg["train_path"])
+    if df_val is None:
+        df_val = _read_dataframe(cfg["val_path"])
+    if df_test is None:
+        df_test = _read_dataframe(cfg["test_path"])
+
+    _validate_dataframe(df_train, "df_train")
+    _validate_dataframe(df_val, "df_val")
+    _validate_dataframe(df_test, "df_test")
+
+    _assert_disjoint_doc_ids(df_train, df_val, df_test)
+
+    df_train = _clean_dataframe(df_train)
+    df_val = _clean_dataframe(df_val)
+    df_test = _clean_dataframe(df_test)
+
+    df_train, dropped_map = drop_near_duplicates(
+        df_train, df_val, df_test, threshold=dup_threshold
+    )
+
+    for name, df in [("df_train", df_train), ("df_val", df_val), ("df_test", df_test)]:
+        print(
+            f"{name} cleaned samples:\n"
+            f"{df[['text', 'text_clean', 'summary', 'summary_clean']].head(3)}\n"
+        )
+
+    _save_splits_to_parquet(df_train, df_val, df_test, cfg)
+
+    return df_train, df_val, df_test, dropped_map
+
+
+def analyze_datasets(
+    df_train: pd.DataFrame,
+    df_val: pd.DataFrame,
+    df_test: pd.DataFrame,
+    output_dir: str = "analysis",
+) -> None:
+    """Plot length histograms and report vocabulary overlap."""
+
+    os.makedirs(output_dir, exist_ok=True)
+    enc = tiktoken.get_encoding("cl100k_base")
+    nlp = spacy.load("en_core_web_sm", disable=["parser", "ner", "textcat"])
+
+    def _percentiles(values: np.ndarray) -> str:
+        p = np.percentile(values, [50, 90, 95, 99])
+        return "p50={:.1f}, p90={:.1f}, p95={:.1f}, p99={:.1f}".format(*p)
+
+    def _lengths(series: pd.Series) -> Tuple[np.ndarray, np.ndarray]:
+        chars = series.str.len().to_numpy()
+        tokens = series.map(lambda x: len(enc.encode(x))).to_numpy()
+        return chars, tokens
+
+    for split, df in [("train", df_train), ("val", df_val), ("test", df_test)]:
+        for col in ["text_clean", "summary_clean"]:
+            chars, tokens = _lengths(df[col])
+            for arr, name in [(chars, "char"), (tokens, "token")]:
+                plt.figure()
+                plt.hist(arr, bins=50)
+                plt.title(f"{split} {col} {name} lengths")
+                plt.xlabel(f"{name} count")
+                plt.ylabel("frequency")
+                plt.tight_layout()
+                out = os.path.join(output_dir, f"{split}_{col}_{name}_hist.png")
+                plt.savefig(out)
+                plt.close()
+                print(f"{split} {col} {name} percentiles: {_percentiles(arr)}")
+
+    def _lemma_set(texts: pd.Series) -> set:
+        return {
+            tok.lemma_.lower()
+            for doc in nlp.pipe(texts.tolist(), batch_size=100)
+            for tok in doc
+            if tok.is_alpha
+        }
+
+    vocabs = {
+        split: {
+            col: _lemma_set(df[col])
+            for col in ["text_clean", "summary_clean"]
+        }
+        for split, df in [("train", df_train), ("val", df_val), ("test", df_test)]
+    }
+
+    def _jaccard(a: set, b: set) -> float:
+        return len(a & b) / len(a | b) if a or b else 0.0
+
+    pairs = [("train", "val"), ("train", "test"), ("val", "test")]
+    for col in ["text_clean", "summary_clean"]:
+        for s1, s2 in pairs:
+            score = _jaccard(vocabs[s1][col], vocabs[s2][col])
+            print(f"Jaccard({s1},{s2}) for {col}: {score:.3f}")
+
+
+def _extract_section(text: str, header_regex: str) -> Optional[str]:
+    """Return section text following a header pattern or ``None``.
+
+    Parameters
+    ----------
+    text : str
+        Document text to search.
+    header_regex : str
+        Regular expression matching the section header (without the colon).
+    """
+
+    pattern = rf"({header_regex}):?(.*?)(?=\n[A-Z][A-Z ]{{2,}}:|$)"
+    match = re.search(pattern, text, flags=re.IGNORECASE | re.DOTALL)
+    return match.group(2).strip() if match else None
+
+
+def build_summarization_dataset(df: pd.DataFrame) -> pd.DataFrame:
+    """Prepare abstractive summarization prompts and targets."""
+
+    out = df[["doc_id", "text_clean", "summary_clean"]].copy()
+    out["prompt"] = out["text_clean"].map(
+        lambda x: build_prompt(x, style="summarization")
+    )
+    out["target"] = out["summary_clean"]
+    return out[["doc_id", "prompt", "target"]]
+
+
+def build_legal_qa_dataset(df: pd.DataFrame) -> pd.DataFrame:
+    """Generate synthetic question/answer pairs from ISSUE and HOLDING sections."""
+
+    rows = []
+    for _, row in df.iterrows():
+        issue = _extract_section(row["text_clean"], "ISSUE")
+        holding = _extract_section(row["text_clean"], "HOLDING|HELD")
+        if issue and holding:
+            prompt = build_prompt(
+                row["text_clean"], style="qa", question=issue
+            )
+            rows.append({"doc_id": row["doc_id"], "prompt": prompt, "target": holding})
+    return pd.DataFrame(rows)
+
+
+def build_headnote_dataset(df: pd.DataFrame) -> pd.DataFrame:
+    """Construct headnote generation pairs with structured targets."""
+
+    rows = []
+    for _, row in df.iterrows():
+        facts = _extract_section(row["text_clean"], "FACTS")
+        issue = _extract_section(row["text_clean"], "ISSUE")
+        holding = _extract_section(row["text_clean"], "HOLDING|HELD")
+        reasoning = _extract_section(row["text_clean"], "REASONING")
+        parts = []
+        if facts:
+            parts.append(f"Facts: {facts}")
+        if issue:
+            parts.append(f"Issue: {issue}")
+        if holding:
+            parts.append(f"Holding: {holding}")
+        if reasoning:
+            parts.append(f"Reasoning: {reasoning}")
+        if parts:
+            prompt = build_prompt(row["text_clean"], style="headnote")
+            rows.append({"doc_id": row["doc_id"], "prompt": prompt, "target": "\n".join(parts)})
+    return pd.DataFrame(rows)
+
+
+if __name__ == "__main__":
+    sample = {
+        "doc_id": [1, 2, 3],
+        "text": [
+            "FACTS: Judge Alice Smith heard the case. Page 1\nJohn Doe appeared.",
+            "ISSUE: Whether — given the evidence — the defendant Jane Roe was liable.",
+            "HELD: Justice Bob Jones concluded the matter on page 2.",
+        ],
+        "summary": [
+            "Judge Alice Smith summarized the facts.",
+            "The issue involved Jane Roe's liability.",
+            "Justice Bob Jones delivered the holding.",
+        ],
+    }
+    df_t = pd.DataFrame(sample)
+    df_v = pd.DataFrame(sample)
+    df_te = pd.DataFrame(sample)
+    t, v, te, dropped = load_dataframes(df_t, df_v, df_te)
+    print(f"Dropped map: {dropped}")
+    analyze_datasets(t, v, te)
+
+    print("\nSummarization dataset sample:")
+    print(build_summarization_dataset(t).head())
+
+    print("\nLegal QA dataset sample:")
+    print(build_legal_qa_dataset(t).head())
+
+    print("\nHeadnote dataset sample:")
+    print(build_headnote_dataset(t).head())

--- a/prompts.py
+++ b/prompts.py
@@ -1,0 +1,28 @@
+PROMPT_TEMPLATES = {
+    "headnote": (
+        "SYSTEM: You are a careful legal analyst. Summarize faithfully without hallucinating.\n"
+        "USER: Produce a concise legal summary with Facts, Issue, Holding, Reasoning.\n"
+        "INPUT: {text}\n"
+        "OUTPUT:"
+    ),
+    "summarization": (
+        "SYSTEM: You are a careful legal analyst. Summarize the document accurately and concisely.\n"
+        "USER: Summarize the following legal text.\n"
+        "INPUT: {text}\n"
+        "OUTPUT:"
+    ),
+    "qa": (
+        "SYSTEM: You are a careful legal analyst. Answer the question using only the provided document.\n"
+        "USER: {question}\n"
+        "INPUT: {text}\n"
+        "OUTPUT:"
+    ),
+}
+
+
+def build_prompt(text: str, style: str = "headnote", **kwargs) -> str:
+    """Return a formatted prompt for ``text`` according to ``style``."""
+    template = PROMPT_TEMPLATES.get(style)
+    if template is None:
+        raise KeyError(f"Unknown style: {style}")
+    return template.format(text=text, **kwargs)

--- a/setup_colab.py
+++ b/setup_colab.py
@@ -1,0 +1,74 @@
+import os
+import sys
+import subprocess
+import random
+import platform
+
+PACKAGES = [
+    "transformers>=4.42",
+    "datasets",
+    "accelerate",
+    "peft",
+    "bitsandbytes",
+    "sentencepiece",
+    "evaluate",
+    "rouge_score",
+    "bert_score",
+    "wandb",
+    "pandas",
+    "matplotlib",
+    "scikit-learn",
+    "faiss-cpu",
+    "nltk",
+    "tiktoken",
+    "unidecode",
+    "spacy",
+]
+
+def install_packages():
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "-q"] + PACKAGES)
+
+
+def ensure_spacy_model(model: str = "en_core_web_sm"):
+    try:
+        import spacy
+        spacy.load(model)
+    except (ImportError, OSError):
+        subprocess.check_call([sys.executable, "-m", "spacy", "download", model])
+        import spacy  # noqa: F401
+        spacy.load(model)
+
+
+def set_seed(seed: int = 42):
+    import numpy as np
+    import torch
+
+    os.environ["PYTHONHASHSEED"] = str(seed)
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
+
+
+def print_system_info():
+    import torch
+
+    print(f"Python version: {sys.version}")
+    print(f"PyTorch version: {torch.__version__}")
+    if torch.cuda.is_available():
+        print("CUDA is available")
+        print(f"CUDA version: {torch.version.cuda}")
+        print(f"GPU: {torch.cuda.get_device_name(0)}")
+    else:
+        print("CUDA not available. Using CPU")
+    print(f"CPU: {platform.processor()}")
+
+
+if __name__ == "__main__":
+    install_packages()
+    ensure_spacy_model()
+    print_system_info()
+    set_seed(42)
+    print("Random seeds set to 42")


### PR DESCRIPTION
## Summary
- extend dataset utilities with `analyze_datasets` to plot character/token length histograms using tiktoken and to compute Jaccard vocabulary overlap across splits
- document dataset statistics workflow and add matplotlib dependency to the Colab setup script
- drop near-duplicate `text_clean` entries from the training split using a SimHash threshold and return the removed `doc_id` mapping
- verify that `doc_id` values do not overlap across splits and persist the cleaned splits as canonical Parquet files
- implement `build_summarization_dataset`, `build_legal_qa_dataset`, and `build_headnote_dataset` to generate `prompt`/`target` pairs for summarization, QA, and structured headnotes
- introduce reusable `SYSTEM`/`USER` prompt templates and a `build_prompt` helper, wiring them into dataset builders and documenting their usage

## Testing
- `pip install pandas matplotlib tiktoken spacy` *(fails: Could not find a version that satisfies the requirement pandas)*
- `python data_utils.py` *(fails: ModuleNotFoundError: No module named 'matplotlib')*
- `python setup_colab.py` *(fails: Could not find a version that satisfies the requirement transformers>=4.42)*

------
https://chatgpt.com/codex/tasks/task_e_68aac1187ab083269989905f2b7b546b